### PR TITLE
fix: update bigquery client default project BigQuery.ts

### DIFF
--- a/packages/back-end/src/integrations/BigQuery.ts
+++ b/packages/back-end/src/integrations/BigQuery.ts
@@ -37,7 +37,7 @@ export default class BigQuery extends SqlIntegration {
     // If pull credentials from env or the metadata server
     if (!IS_CLOUD && this.params.authType === "auto") {
       return new bq.BigQuery({
-        projectId: this.params.defaultProject
+        projectId: this.params.defaultProject,
       });
     }
 

--- a/packages/back-end/src/integrations/BigQuery.ts
+++ b/packages/back-end/src/integrations/BigQuery.ts
@@ -36,11 +36,11 @@ export default class BigQuery extends SqlIntegration {
   private getClient() {
     // If pull credentials from env or the metadata server
     if (!IS_CLOUD && this.params.authType === "auto") {
-      return new bq.BigQuery();
+      return new bq.BigQuery(this.params.defaultProject);
     }
 
     return new bq.BigQuery({
-      projectId: this.params.projectId,
+      projectId: this.params.defaultProject,
       credentials: {
         client_email: this.params.clientEmail,
         private_key: this.params.privateKey,

--- a/packages/back-end/src/integrations/BigQuery.ts
+++ b/packages/back-end/src/integrations/BigQuery.ts
@@ -36,7 +36,9 @@ export default class BigQuery extends SqlIntegration {
   private getClient() {
     // If pull credentials from env or the metadata server
     if (!IS_CLOUD && this.params.authType === "auto") {
-      return new bq.BigQuery(this.params.defaultProject);
+      return new bq.BigQuery({
+        projectId: this.params.defaultProject
+      });
     }
 
     return new bq.BigQuery({


### PR DESCRIPTION
### Features and Changes

This includes changes to make Bigquery work in auto credentials mode, where the GCP project which has Bigquery can be in a different project than where Growthbook is deployed. The Bigquery client was either not being initialised with the project or it was being initialised with Growthbook project id which was incorrect.

We encountered this issue when we were trying to deploy Growthbook on our K8s


### Testing

BQ will connect to default project even if Growthbook is deployed to different GCP project


